### PR TITLE
Change target standard to gnu11 and fix warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-c -O2 -Wall -Wextra -pedantic -Wno-implicit-fallthrough -std=gnu99
+CFLAGS=-c -O2 -Wall -Wextra -pedantic -Wno-implicit-fallthrough -std=gnu11
 LFLAGS=-O2 -Wall -Wextra -pedantic -lm
 
 all: s2rd panoramacompiler panorepack

--- a/dmx/dmxbraw.c
+++ b/dmx/dmxbraw.c
@@ -296,6 +296,7 @@ dmx* V(dmx_from_buffer) (char* buffer, const unsigned int length) {
 #undef READSTRING
 
 // take a memory dmx, and put it in a data file appropriately
+/* TODO
 char* V(dmx_to_buffer) (dmx* in, long* length) {
 	if(in==NULL) {
 		fprintf(stderr, "Error: Tried writing dmx to null buffer!\n");
@@ -323,3 +324,4 @@ char* V(dmx_to_buffer) (dmx* in, long* length) {
 	*length = 0;
 	return NULL;
 }
+*/


### PR DESCRIPTION
Code now builds without warnings in GCC with gnu11
as the standard.